### PR TITLE
Update for jQuery 3 support

### DIFF
--- a/jquery-photo-resize.js
+++ b/jquery-photo-resize.js
@@ -28,7 +28,7 @@
 
 		options = $.extend(defaults, options);
         
-        $(element).load(function () {
+        $(element).on('load', function () {
             changeDimensions();
         });
         // the load event is a bit tricky -- it seems to not fire if


### PR DESCRIPTION
In jQuery 3.x `.load(cb)` isn't equivalent to `.on('load', cb)` anymore.
With this change, the plugin works fine on jQuery 3 (tested on 3.2.1).